### PR TITLE
Strip trailing whitespace

### DIFF
--- a/napalm_ruckus_fastiron/FastIron.py
+++ b/napalm_ruckus_fastiron/FastIron.py
@@ -491,6 +491,7 @@ class FastIronDriver(NetworkDriver):
     @staticmethod
     def __compare_blocks(cb_1, config_blocks_2, cmd, symbol):
         temp_list = list()
+        stat = False
         for cb_2 in config_blocks_2:                # grabs a single config block
             if cmd == cb_2[0]:                      # checks cmd not found
                 stat = True
@@ -510,6 +511,7 @@ class FastIronDriver(NetworkDriver):
         for cb_1 in config_blocks_1:                # Grabs a single config block
             is_found = False
 
+            temp_list = list()
             if cb_1 not in config_blocks_2:         # checks if config block already exisit
                 cmd = cb_1[0]                       # grabs first cmd of config block
 

--- a/napalm_ruckus_fastiron/FastIron.py
+++ b/napalm_ruckus_fastiron/FastIron.py
@@ -21,7 +21,7 @@ from __future__ import unicode_literals
 from netmiko import ConnectHandler
 import socket
 import sys
-# import re
+import re
 
 # local modules
 # import napalm.base.exceptions
@@ -489,16 +489,22 @@ class FastIronDriver(NetworkDriver):
         return config_block
 
     @staticmethod
+    def __strip_trailing_whitespace(cmd):
+        strip = re.compile(r"(\s*([^\s]*[\s]*[^\s+]+)+)\s*$")
+        return strip.match(cmd).group(1)
+
+    @staticmethod
     def __compare_blocks(cb_1, config_blocks_2, cmd, symbol):
         temp_list = list()
         stat = False
         for cb_2 in config_blocks_2:                # grabs a single config block
-            if cmd == cb_2[0]:                      # checks cmd not found
+            if FastIronDriver.__strip_trailing_whitespace(cmd) == FastIronDriver.__strip_trailing_whitespace(cb_2[0]):                      # checks cmd not found
                 stat = True
                 for single_cmd in cb_1:             # iterates through cmd of config block
-                    if single_cmd == cmd:           # if this is first command add as base
+                    if FastIronDriver.__strip_trailing_whitespace(single_cmd) == FastIronDriver.__strip_trailing_whitespace(cmd):           # if this is first command add as base
                         temp_list.append(single_cmd)  # add to list with no changes
-                    elif single_cmd not in cb_2:
+                    elif FastIronDriver.__strip_trailing_whitespace(single_cmd) not in list(map(FastIronDriver.__strip_trailing_whitespace, cb_2)):
+                        print(list(map(FastIronDriver.__strip_trailing_whitespace, cb_2)))
                         temp_list.append(symbol + " " + single_cmd)
         return temp_list, stat
 

--- a/napalm_ruckus_fastiron/FastIron.py
+++ b/napalm_ruckus_fastiron/FastIron.py
@@ -659,8 +659,8 @@ class FastIronDriver(NetworkDriver):
         else:
             return -1                           # No configuration was found
 
-        diff_1 = FastIronDriver.__comparing_list(rc, stored_conf, "+")
-        diff_2 = FastIronDriver.__comparing_list(stored_conf, rc, "-")
+        diff_1 = FastIronDriver.__comparing_list(rc, stored_conf, "-")
+        diff_2 = FastIronDriver.__comparing_list(stored_conf, rc, "+")
 
         str_diff1 = FastIronDriver.__compare_away(diff_1, diff_2)
         str_diff2 = FastIronDriver.__compare_vice(diff_2, diff_1)
@@ -683,9 +683,9 @@ class FastIronDriver(NetworkDriver):
 
             for sentence in my_temp:
 
-                if sentence[0] == '-':
+                if sentence[0] == '+':
                     sentence = sentence[1:len(sentence)]
-                elif sentence[0] == '+':
+                elif sentence[0] == '-':
                     sentence = 'no' + sentence[1:len(sentence)]
                 replace_list.append(sentence)
 


### PR DESCRIPTION
This builds on #4 

When testing out `compare_config()`, I noticed that the diff was much larger than I would have expected it to be. This is the result of my text editor automatically removing trailing whitespace and the running config having considerable trailing whitespace in it.

I would understand if this isn't a change you would like in the library.